### PR TITLE
Multi device key support

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,8 +4,15 @@ require "net/http"
 class NotificationsController < ApplicationController
 
     def test_notification
+        # Get  infectedIDs (tempIDs, date) from Infection API
+        rawInfectedIDs = [{"date":"2020-10-27T17:35:19.827Z","tempID":"092830j209f2"},{"date":"2020-10-27T17:35:19.827Z","tempID":"weokeokwpowe"}]
+        # format the infectedIDs so they can be embbeded
+        @infectedIDs = JSON.generate(rawInfectedIDs) # => "{\"hello\":\"goodbye\"}"
+
+        # Get deviceKeys from Auth API
         device_tokens = params[:deviceTokens]
 
+        # Send notifications to all users
         device_tokens.each do |device_token|
             send_notification(device_token)
         end
@@ -24,6 +31,7 @@ class NotificationsController < ApplicationController
     end
 
     def send_apns_notification(device_token)
+        # Create notification
         n = Rpush::Apns::Notification.new
         n.app = Rpush::Apns::App.find_by_name("parliament_ios")
         n.device_token = device_token
@@ -34,20 +42,16 @@ class NotificationsController < ApplicationController
         # pass any custom data here
         n.data = {
             type: 'message',
-            user_name: 'Bob',
+            infectedIDs: @infectedIDs,
         }
         n.sound = "water_droplet_3.wav"
         n.content_available = true
         n.save!
-        
+        # Send Notification
         Rpush.push
     end
 
     def send_fcm_notification(device_token)
-        # Get the infected IDs and their dates
-        rawInfectedIDs = [{"date":"2020-10-27T17:35:19.827Z","tempID":"092830j209f2"},{"date":"2020-10-27T17:35:19.827Z","tempID":"weokeokwpowe"}]
-        # Format for embedding into request
-        infectedIDs = JSON.generate(rawInfectedIDs) # => "{\"hello\":\"goodbye\"}"
         # Assemble Request
         url = URI("https://fcm.googleapis.com/fcm/send")
         https = Net::HTTP.new(url.host, url.port);
@@ -56,7 +60,7 @@ class NotificationsController < ApplicationController
         request["Authorization"] = "key=AAAAQPfWnqU:APA91bELotc45F69FyZUtQL5A4NnrIVwS-CsiMOE2OaWWgrcf53v3tvrbVdkZoL-b7ApjfgygOdN3Dd8neo45NGnpIhof8WfQ1pllAxXv3DWL3nVu1x36oOVnrTL09AH0sc9CnfRMir1"
         request["Content-Type"] = "application/json"
         request["Host"] = "fcm.googleapis.com"
-        request.body = "{\n    \"to\":\"#{device_token}\",\n    \"notification\" : {\n     \"body\" : \"please work\",\n     \"title\": \"Notification from postman\"\n    },\n    \"data\" : {\n        \"body\" : \"please work\",\n        \"title\": \"Notification from postman\",\n        \"infectedIDs\": #{infectedIDs}  }\n}"
+        request.body = "{\n    \"to\":\"#{device_token}\",\n    \"notification\" : {\n     \"body\" : \"please work\",\n     \"title\": \"Notification from postman\"\n    },\n    \"data\" : {\n        \"body\" : \"please work\",\n        \"title\": \"Notification from postman\",\n        \"infectedIDs\": #{@infectedIDs}  }\n}"
         # Send Request
         response = https.request(request)
         # Send Feedback

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -8,8 +8,9 @@ class NotificationsController < ApplicationController
 
         device_tokens.each do |device_token|
             send_notification(device_token)
-         end
-        
+        end
+        render json: {status: "Successfully sent notifications"}
+
     end
 
     private 
@@ -43,20 +44,22 @@ class NotificationsController < ApplicationController
     end
 
     def send_fcm_notification(device_token)
+        # Get the infected IDs and their dates
+        rawInfectedIDs = [{"date":"2020-10-27T17:35:19.827Z","tempID":"092830j209f2"},{"date":"2020-10-27T17:35:19.827Z","tempID":"weokeokwpowe"}]
+        # Format for embedding into request
+        infectedIDs = JSON.generate(rawInfectedIDs) # => "{\"hello\":\"goodbye\"}"
+        # Assemble Request
         url = URI("https://fcm.googleapis.com/fcm/send")
-
         https = Net::HTTP.new(url.host, url.port);
         https.use_ssl = true
-        
         request = Net::HTTP::Post.new(url)
         request["Authorization"] = "key=AAAAQPfWnqU:APA91bELotc45F69FyZUtQL5A4NnrIVwS-CsiMOE2OaWWgrcf53v3tvrbVdkZoL-b7ApjfgygOdN3Dd8neo45NGnpIhof8WfQ1pllAxXv3DWL3nVu1x36oOVnrTL09AH0sc9CnfRMir1"
         request["Content-Type"] = "application/json"
         request["Host"] = "fcm.googleapis.com"
-        request.body = "{\n    \"to\":\"#{device_token}\",\n    \"notification\" : {\n     \"body\" : \"please work\",\n     \"title\": \"Notification from postman\"\n    },\n    \"data\" : {\n        \"body\" : \"please work\",\n        \"title\": \"Notification from postman\",\n        \"key_1\" : \"Value for key_1\",\n        \"key_2\" : \"Value for key_2\"\n    }\n}"
-        
+        request.body = "{\n    \"to\":\"#{device_token}\",\n    \"notification\" : {\n     \"body\" : \"please work\",\n     \"title\": \"Notification from postman\"\n    },\n    \"data\" : {\n        \"body\" : \"please work\",\n        \"title\": \"Notification from postman\",\n        \"infectedIDs\": #{infectedIDs}  }\n}"
+        # Send Request
         response = https.request(request)
-
-        render json: response.read_body
+        # Send Feedback
     end
 
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,9 +4,11 @@ require "net/http"
 class NotificationsController < ApplicationController
 
     def test_notification
-        device_token = params[:deviceToken]
+        device_tokens = params[:deviceTokens]
 
-        send_notification(device_token)
+        device_tokens.each do |device_token|
+            send_notification(device_token)
+         end
         
     end
 


### PR DESCRIPTION
# What was accomplished?
- Added support for sending the infectedIDs json array in the payload of a FCM and APNs notification
     - Note that the infectedIDs are still hardcoded in the notification API

# How was this tested?
- Manually tested that iOS and Android could receive the properly formatted infectedIDs json array

# New Dependencies?
- Nope!