### PR TITLE
Pulling deviceTokens and infectedIDs from Production Auth and Infection API endpoints

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,10 +4,8 @@ require "net/http"
 class NotificationsController < ApplicationController
 
     def test_notification
-        # Get  infectedIDs (tempIDs, date) from Infection API
-        rawInfectedIDs = [{"date":"2020-10-27T17:35:19.827Z","tempID":"092830j209f2"},{"date":"2020-10-27T17:35:19.827Z","tempID":"weokeokwpowe"}]
-        # format the infectedIDs so they can be embbeded
-        @infectedIDs = JSON.generate(rawInfectedIDs) # => "{\"hello\":\"goodbye\"}"
+        # Get  infectedIDs (temp_id, created_date) from Infection API
+        @infectedIDs = get_infected_ids
 
         # Get deviceKeys from Auth API
         device_tokens = get_device_tokens
@@ -21,6 +19,23 @@ class NotificationsController < ApplicationController
     end
 
     private 
+
+    def get_infected_ids
+        url_string = ENV['INFECTION_URI'] + "/temp_ids"
+        url = URI(url_string)
+        http = Net::HTTP.new(url.host, url.port);
+        request = Net::HTTP::Post.new(url)
+        request["Content-Type"] = "application/json"
+        request.body = "{\n  \"accessToken\":\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo3LCJ0eXBlIjoiYWNjZXNzIiwic2FsdCI6IkRuUUxDNUBaIn0.XYP-vxVsgGKc0rrzD3oOB-tQll3RDnNJHWAUudWysIg\"\n}"
+        
+        response = http.request(request)
+        # Format the response
+        result_json = JSON.parse(response.read_body)
+        rawInfectedIDs = result_json['temp_ids']
+        # Remove null entries
+        rawInfectedIDs -= [nil]
+        JSON.generate(rawInfectedIDs)
+    end
 
     def get_device_tokens
         url_string = ENV['AUTH_URI'] + "/device_keys"

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -10,8 +10,8 @@ class NotificationsController < ApplicationController
         @infectedIDs = JSON.generate(rawInfectedIDs) # => "{\"hello\":\"goodbye\"}"
 
         # Get deviceKeys from Auth API
-        device_tokens = params[:deviceTokens]
-
+        device_tokens = get_device_tokens
+        
         # Send notifications to all users
         device_tokens.each do |device_token|
             send_notification(device_token)
@@ -21,6 +21,22 @@ class NotificationsController < ApplicationController
     end
 
     private 
+
+    def get_device_tokens
+        url_string = ENV['AUTH_URI'] + "/device_keys"
+        url = URI(url_string)
+        http = Net::HTTP.new(url.host, url.port);
+        request = Net::HTTP::Post.new(url)
+        request["Content-Type"] = "application/json"
+        request.body = "{\n    \"accessToken\": \"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo2LCJ0eXBlIjoiYWNjZXNzIiwic2FsdCI6IlNwVlc0QlBLIn0.86XNvLqt7Hb9bNCDymtflsim89I4B0iIoYEXbKd0JxI\"\n}"
+        # Send Request
+        response = http.request(request)
+        # Format the response
+        result_json = JSON.parse(response.read_body)
+        device_tokens = result_json['device_keys']
+        # Remove null entries
+        device_tokens -= [nil]
+    end
 
     def send_notification(device_token)
         if device_token.length < 162

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,7 @@ Rails.application.configure do
 
 
   ENV['AUTH_URI'] = "http://localhost:3000"
+  ENV['INFECTION_URI'] = "http://localhost:3001"
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,6 +25,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+
+  ENV['AUTH_URI'] = "http://localhost:3000"
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   ENV['AUTH_URI'] = "http://a87713a1fd4b64cd4b788e8a1592de07-1206905140.us-west-2.elb.amazonaws.com"
-  ENV['INFECTION_URI'] = "a73906904480049e69678e0cb9be2e22-1728580132.us-east-2.elb.amazonaws.com"
+  ENV['INFECTION_URI'] = "http://a73906904480049e69678e0cb9be2e22-1728580132.us-east-2.elb.amazonaws.com"
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   ENV['AUTH_URI'] = "http://a87713a1fd4b64cd4b788e8a1592de07-1206905140.us-west-2.elb.amazonaws.com"
+  ENV['INFECTION_URI'] = "a73906904480049e69678e0cb9be2e22-1728580132.us-east-2.elb.amazonaws.com"
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,6 +82,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  ENV['AUTH_URI'] = "http://a87713a1fd4b64cd4b788e8a1592de07-1206905140.us-west-2.elb.amazonaws.com"
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
# What was accomplished?
- Added Auth and Infection API calls to get device keys and infection IDs respectively

# How was this tested?
- Manually tested that iOS and Android can receive notifications and parse the infectedIDs stringified JSON

# New Dependencies?
- Nope! :)